### PR TITLE
Target .NET 8 Android/iOS platforms

### DIFF
--- a/MobileRankingSystem.sln
+++ b/MobileRankingSystem.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32811.315
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MobileRankingSystem", "MobileRankingSystem\MobileRankingSystem.csproj", "{3C1FA7C4-314A-4E78-B2A5-3E6959941C3C}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{3C1FA7C4-314A-4E78-B2A5-3E6959941C3C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{3C1FA7C4-314A-4E78-B2A5-3E6959941C3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{3C1FA7C4-314A-4E78-B2A5-3E6959941C3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{3C1FA7C4-314A-4E78-B2A5-3E6959941C3C}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal

--- a/MobileRankingSystem/App.xaml
+++ b/MobileRankingSystem/App.xaml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="MobileRankingSystem.App">
+    <Application.Resources>
+        <ResourceDictionary>
+            <Color x:Key="PrimaryColor">#2563EB</Color>
+            <Color x:Key="SecondaryColor">#4F46E5</Color>
+            <Style TargetType="ContentPage">
+                <Setter Property="BackgroundColor" Value="White" />
+            </Style>
+            <Style TargetType="Label">
+                <Setter Property="TextColor" Value="#1F2937" />
+            </Style>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/MobileRankingSystem/App.xaml.cs
+++ b/MobileRankingSystem/App.xaml.cs
@@ -1,0 +1,13 @@
+using Microsoft.Maui.Controls;
+
+namespace MobileRankingSystem;
+
+public partial class App : Application
+{
+    public App()
+    {
+        InitializeComponent();
+
+        MainPage = new AppShell();
+    }
+}

--- a/MobileRankingSystem/AppShell.xaml
+++ b/MobileRankingSystem/AppShell.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Shell
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MobileRankingSystem"
+    x:Class="MobileRankingSystem.AppShell">
+    <ShellContent
+        Title="Rankings"
+        ContentTemplate="{DataTemplate local:MainPage}" />
+</Shell>

--- a/MobileRankingSystem/AppShell.xaml.cs
+++ b/MobileRankingSystem/AppShell.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace MobileRankingSystem;
+
+public partial class AppShell : Shell
+{
+    public AppShell()
+    {
+        InitializeComponent();
+    }
+}

--- a/MobileRankingSystem/MainPage.xaml
+++ b/MobileRankingSystem/MainPage.xaml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewmodels="clr-namespace:MobileRankingSystem.ViewModels"
+             x:Class="MobileRankingSystem.MainPage">
+    <ContentPage.BindingContext>
+        <viewmodels:RankingViewModel />
+    </ContentPage.BindingContext>
+
+    <ScrollView>
+        <VerticalStackLayout Padding="24" Spacing="16">
+            <Label Text="Team Rankings"
+                   FontAttributes="Bold"
+                   FontSize="24"
+                   HorizontalOptions="Center" />
+
+            <CollectionView ItemsSource="{Binding RankedTeams}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Frame Padding="16" Margin="0,8" BackgroundColor="#EEF2FF" CornerRadius="12">
+                            <VerticalStackLayout Spacing="8">
+                                <HorizontalStackLayout Spacing="12">
+                                    <Label Text="{Binding Rank}" FontAttributes="Bold" FontSize="20" />
+                                    <Label Text="{Binding TeamName}" FontAttributes="Bold" FontSize="20" />
+                                </HorizontalStackLayout>
+                                <Label Text="{Binding Summary}" FontSize="14" />
+                                <Label Text="{Binding PlayersSummary}" FontSize="12" TextColor="#4B5563" />
+                            </VerticalStackLayout>
+                        </Frame>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+
+            <Label Text="Upcoming Improvements"
+                   FontAttributes="Bold"
+                   FontSize="18"
+                   HorizontalOptions="Center" />
+            <Label Text="• Add persistent storage\n• Support manual match entry\n• Sync with cloud services" />
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/MobileRankingSystem/MainPage.xaml.cs
+++ b/MobileRankingSystem/MainPage.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace MobileRankingSystem;
+
+public partial class MainPage : ContentPage
+{
+    public MainPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/MobileRankingSystem/MauiProgram.cs
+++ b/MobileRankingSystem/MauiProgram.cs
@@ -1,0 +1,17 @@
+using Microsoft.Maui;
+using Microsoft.Maui.Controls.Hosting;
+using Microsoft.Maui.Hosting;
+
+namespace MobileRankingSystem;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder
+            .UseMauiApp<App>();
+
+        return builder.Build();
+    }
+}

--- a/MobileRankingSystem/MobileRankingSystem.csproj
+++ b/MobileRankingSystem/MobileRankingSystem.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0-android;net8.0-ios</TargetFrameworks>
+    <UseMaui>true</UseMaui>
+    <SingleProject>true</SingleProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <ApplicationTitle>Mobile Ranking System</ApplicationTitle>
+    <ApplicationId>com.example.mobilerankingsystem</ApplicationId>
+    <ApplicationIdGuid>12345678-90ab-cdef-1234-567890abcdef</ApplicationIdGuid>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <MauiXaml Update="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="AppShell.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="MainPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+  </ItemGroup>
+</Project>

--- a/MobileRankingSystem/Models/MatchResult.cs
+++ b/MobileRankingSystem/Models/MatchResult.cs
@@ -1,0 +1,21 @@
+namespace MobileRankingSystem.Models;
+
+public class MatchResult
+{
+    public MatchResult(Team teamA, Team teamB, Team? winner, int teamAScore, int teamBScore)
+    {
+        TeamA = teamA;
+        TeamB = teamB;
+        Winner = winner;
+        TeamAScore = teamAScore;
+        TeamBScore = teamBScore;
+    }
+
+    public Team TeamA { get; }
+    public Team TeamB { get; }
+    public Team? Winner { get; }
+    public int TeamAScore { get; }
+    public int TeamBScore { get; }
+
+    public bool IsDraw => TeamAScore == TeamBScore;
+}

--- a/MobileRankingSystem/Models/Player.cs
+++ b/MobileRankingSystem/Models/Player.cs
@@ -1,0 +1,3 @@
+namespace MobileRankingSystem.Models;
+
+public record Player(string Name, int SkillRating);

--- a/MobileRankingSystem/Models/Team.cs
+++ b/MobileRankingSystem/Models/Team.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MobileRankingSystem.Models;
+
+public class Team
+{
+    public Team(string name, IEnumerable<Player> players)
+    {
+        Name = name;
+        Players = players.ToList();
+    }
+
+    public string Name { get; }
+
+    public IReadOnlyList<Player> Players { get; }
+
+    public int TotalSkill => Players.Sum(p => p.SkillRating);
+}

--- a/MobileRankingSystem/Services/RankingService.cs
+++ b/MobileRankingSystem/Services/RankingService.cs
@@ -1,0 +1,122 @@
+using MobileRankingSystem.Models;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MobileRankingSystem.Services;
+
+public class RankingService
+{
+    public IReadOnlyList<TeamRanking> GenerateRankings(IEnumerable<MatchResult> results)
+    {
+        var scores = new Dictionary<string, int>();
+        var matchesPlayed = new Dictionary<string, int>();
+        var teamLookup = new Dictionary<string, Team>();
+
+        foreach (var result in results)
+        {
+            RegisterTeam(result.TeamA);
+            RegisterTeam(result.TeamB);
+
+            Increment(matchesPlayed, result.TeamA.Name);
+            Increment(matchesPlayed, result.TeamB.Name);
+
+            if (result.IsDraw)
+            {
+                AddPoints(result.TeamA.Name, 1);
+                AddPoints(result.TeamB.Name, 1);
+            }
+            else if (result.Winner is not null)
+            {
+                AddPoints(result.Winner.Name, 3);
+            }
+        }
+
+        return scores
+            .Select(kvp =>
+            {
+                teamLookup.TryGetValue(kvp.Key, out var team);
+                return new TeamRanking(
+                    kvp.Key,
+                    kvp.Value,
+                    matchesPlayed.TryGetValue(kvp.Key, out var played) ? played : 0)
+                { Team = team };
+            })
+            .OrderByDescending(r => r.Points)
+            .ThenByDescending(r => r.AverageSkill)
+            .Select((ranking, index) => ranking with { Rank = index + 1 })
+            .ToList();
+
+        void RegisterTeam(Team team)
+        {
+            if (!scores.ContainsKey(team.Name))
+            {
+                scores[team.Name] = 0;
+            }
+
+            teamLookup[team.Name] = team;
+        }
+
+        void AddPoints(string teamName, int points)
+        {
+            scores[teamName] = scores.TryGetValue(teamName, out var current) ? current + points : points;
+        }
+
+        static void Increment(IDictionary<string, int> dictionary, string teamName)
+        {
+            dictionary[teamName] = dictionary.TryGetValue(teamName, out var current) ? current + 1 : 1;
+        }
+    }
+
+    public IReadOnlyList<Team> CreateBalancedTeams(IEnumerable<Player> players)
+    {
+        var orderedPlayers = players
+            .OrderByDescending(p => p.SkillRating)
+            .ToList();
+
+        var teams = new List<Team>();
+        int teamNumber = 1;
+
+        while (orderedPlayers.Count >= 2)
+        {
+            var strongest = orderedPlayers.First();
+            orderedPlayers.RemoveAt(0);
+
+            var weakest = orderedPlayers.Last();
+            orderedPlayers.RemoveAt(orderedPlayers.Count - 1);
+
+            teams.Add(new Team($"Team {teamNumber++}", new[] { strongest, weakest }));
+        }
+
+        if (orderedPlayers.Any())
+        {
+            var fallbackTeam = teams.OrderBy(t => t.TotalSkill).FirstOrDefault();
+            if (fallbackTeam is null)
+            {
+                teams.Add(new Team($"Team {teamNumber}", orderedPlayers.ToList()));
+            }
+            else
+            {
+                var updatedPlayers = fallbackTeam.Players.Concat(orderedPlayers).ToList();
+                teams.Remove(fallbackTeam);
+                teams.Add(new Team(fallbackTeam.Name, updatedPlayers));
+            }
+        }
+
+        return teams;
+    }
+}
+
+public record TeamRanking(string TeamName, int Points, int MatchesPlayed)
+{
+    public int Rank { get; init; }
+
+    public string Summary => $"{Points} pts · {MatchesPlayed} matches";
+
+    public string PlayersSummary => string.Join(", ", Team?.Players.Select(p => $"{p.Name} ({p.SkillRating})") ?? Enumerable.Empty<string>());
+
+    public int AverageSkill => Team is null || !Team.Players.Any()
+        ? 0
+        : (int)Team.Players.Average(p => p.SkillRating);
+
+    internal Team? Team { get; init; }
+}

--- a/MobileRankingSystem/ViewModels/RankingViewModel.cs
+++ b/MobileRankingSystem/ViewModels/RankingViewModel.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using MobileRankingSystem.Models;
+using MobileRankingSystem.Services;
+
+namespace MobileRankingSystem.ViewModels;
+
+public class RankingViewModel
+{
+    public RankingViewModel()
+    {
+        var rankingService = new RankingService();
+
+        var players = new List<Player>
+        {
+            new("Alice", 85),
+            new("Bob", 78),
+            new("Charlie", 90),
+            new("Diana", 72),
+            new("Evelyn", 88),
+            new("Frank", 80),
+            new("Grace", 76),
+            new("Hector", 83)
+        };
+
+        var teams = rankingService.CreateBalancedTeams(players);
+
+        var matches = new List<MatchResult>
+        {
+            new(teams[0], teams[1], teams[0], 21, 17),
+            new(teams[2], teams[3], teams[3], 18, 21),
+            new(teams[0], teams[2], teams[0], 25, 20),
+            new(teams[1], teams[3], teams[3], 19, 21),
+            new(teams[0], teams[3], null, 22, 22)
+        };
+
+        RankedTeams = new ObservableCollection<TeamRanking>(
+            rankingService.GenerateRankings(matches));
+    }
+
+    public ObservableCollection<TeamRanking> RankedTeams { get; }
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
 # Mobile-RankingSystem-
-This is going to be a Maui app that could rank people. The rank is going to be decided by matches played by teams of 2, more than 2 teams could play the matches.
-It also has to support creation of teams, given for example 20 persons, make 10 teams maximizing the balance
+
+This repository hosts an MVP for a .NET MAUI application that ranks people who compete in two-player teams. The ranking is determined by the outcomes of matches that can involve more than two teams. The app also demonstrates how to automatically build balanced teams from a pool of available players.
+
+## Project structure
+
+- `MobileRankingSystem.sln` – Visual Studio solution that references the MAUI project.
+- `MobileRankingSystem/` – .NET MAUI single-project structure containing:
+  - `App.xaml` / `App.xaml.cs` – application resources and bootstrap logic.
+  - `AppShell.xaml` – shell navigation definition.
+  - `MainPage.xaml` – first screen that lists calculated team rankings.
+  - `Models/` – core domain entities such as players, teams, and match results.
+  - `Services/RankingService.cs` – logic for creating balanced teams and converting match results into a ranking table.
+  - `ViewModels/RankingViewModel.cs` – sample data pipeline that powers the UI.
+
+## Current functionality
+
+- Builds a set of balanced teams from a list of players with individual skill ratings.
+- Calculates league-style standings using recent match results (win = 3 points, draw = 1 point).
+- Presents the ranking in a simple UI backed by an observable collection.
+- Highlights upcoming improvements for persistence, manual match entry, and cloud sync.
+
+## Getting started
+
+> **Note:** The container used to author this repository does not ship with the .NET SDK or MAUI workloads, so the project cannot be compiled here. The project files were created manually following the default MAUI single-project pattern.
+
+1. Install the [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download) and the required MAUI workloads for Android (add iOS support if you're on macOS) by following the [official setup guide](https://learn.microsoft.com/dotnet/maui/get-started/installation).
+2. Clone the repository and open `MobileRankingSystem.sln` in Visual Studio 2022 (17.8 or later) or run `dotnet build MobileRankingSystem.sln` from a terminal with the MAUI workloads installed.
+3. Deploy primarily to Android (emulator or device); if you have access to the necessary tooling on macOS you can also target iOS from Visual Studio or the `dotnet` CLI.
+
+## Next steps
+
+- Persist match history and player profiles in a lightweight database such as SQLite.
+- Provide UI flows for creating matches, editing scores, and adjusting teams.
+- Integrate authentication and real-time sync for league play.


### PR DESCRIPTION
## Summary
- retarget the MAUI project to .NET 8, focusing on Android with optional iOS support
- update the setup instructions to reference the .NET 8 SDK, newer Visual Studio tooling, and Android-first deployment guidance

## Testing
- not run (environment lacks the .NET SDK and MAUI workloads)


------
https://chatgpt.com/codex/tasks/task_e_68d7ffe48134832ea60765007ddc6ea0