### PR TITLE
Fix MainPage XAML structure and add MAUI controls reference

### DIFF
--- a/MobileRankingSystem/MainPage.xaml
+++ b/MobileRankingSystem/MainPage.xaml
@@ -10,29 +10,32 @@
     <ScrollView>
         <VerticalStackLayout Padding="24" Spacing="16">
             <Label Text="Team Rankings"
-                   Style="{StaticResource SectionHeader}" />
+                   Style="{StaticResource SectionHeader}"
                    FontAttributes="Bold"
                    FontSize="24"
                    HorizontalOptions="Center" />
+
             <CollectionView ItemsSource="{Binding RankedTeams}">
                 <CollectionView.ItemTemplate>
                     <DataTemplate>
-                        <Frame Margin="0,8" Style="{StaticResource CardFrame}">
+                        <Frame Padding="16"
+                               Margin="0,8"
+                               BackgroundColor="#EEF2FF"
+                               CornerRadius="12">
                             <VerticalStackLayout Spacing="8">
                                 <HorizontalStackLayout Spacing="12">
-                                    <Label Text="{Binding Rank}" FontAttributes="Bold" FontFamily="OpenSansSemibold" FontSize="20" />
-                                    <Label Text="{Binding TeamName}" FontAttributes="Bold" FontFamily="OpenSansSemibold" FontSize="20" />
+                                    <Label Text="{Binding Rank}"
+                                           FontAttributes="Bold"
+                                           FontSize="20" />
+                                    <Label Text="{Binding TeamName}"
+                                           FontAttributes="Bold"
+                                           FontSize="20" />
                                 </HorizontalStackLayout>
-                                <Label Text="{Binding Summary}" FontSize="14" />
-                                <Label Text="{Binding PlayersSummary}" FontSize="12" TextColor="{StaticResource TextSecondary}" />
-                        <Frame Padding="16" Margin="0,8" BackgroundColor="#EEF2FF" CornerRadius="12">
-                            <VerticalStackLayout Spacing="8">
-                                <HorizontalStackLayout Spacing="12">
-                                    <Label Text="{Binding Rank}" FontAttributes="Bold" FontSize="20" />
-                                    <Label Text="{Binding TeamName}" FontAttributes="Bold" FontSize="20" />
-                                </HorizontalStackLayout>
-                                <Label Text="{Binding Summary}" FontSize="14" />
-                                <Label Text="{Binding PlayersSummary}" FontSize="12" TextColor="#4B5563" />
+                                <Label Text="{Binding Summary}"
+                                       FontSize="14" />
+                                <Label Text="{Binding PlayersSummary}"
+                                       FontSize="12"
+                                       TextColor="#4B5563" />
                             </VerticalStackLayout>
                         </Frame>
                     </DataTemplate>
@@ -40,11 +43,11 @@
             </CollectionView>
 
             <Label Text="Upcoming Improvements"
-                   Style="{StaticResource SubsectionHeader}" />
+                   Style="{StaticResource SubsectionHeader}"
                    FontAttributes="Bold"
                    FontSize="18"
                    HorizontalOptions="Center" />
-            <Label Text="• Add persistent storage\n• Support manual match entry\n• Sync with cloud services" />
+            <Label Text="• Add persistent storage&#x0A;• Support manual match entry&#x0A;• Sync with cloud services" />
         </VerticalStackLayout>
     </ScrollView>
 </ContentPage>

--- a/MobileRankingSystem/MobileRankingSystem.csproj
+++ b/MobileRankingSystem/MobileRankingSystem.csproj
@@ -37,4 +37,8 @@
     <MauiFont Include="Resources/Fonts/OpenSans-Regular.ttf" Alias="OpenSansRegular" />
     <MauiFont Include="Resources/Fonts/OpenSans-Semibold.ttf" Alias="OpenSansSemibold" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.100" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- correct the MainPage XAML hierarchy to avoid invalid markup and duplicate frames
- add an explicit Microsoft.Maui.Controls package reference required for .NET 8 MAUI projects

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d81f701490832e9ba3d6d1f2c656c2