### PR TITLE
Fix platform conditional includes and restore MAUI dependencies

### DIFF
--- a/MobileRankingSystem/MainPage.xaml
+++ b/MobileRankingSystem/MainPage.xaml
@@ -10,29 +10,32 @@
     <ScrollView>
         <VerticalStackLayout Padding="24" Spacing="16">
             <Label Text="Team Rankings"
-                   Style="{StaticResource SectionHeader}" />
+                   Style="{StaticResource SectionHeader}"
                    FontAttributes="Bold"
                    FontSize="24"
                    HorizontalOptions="Center" />
+
             <CollectionView ItemsSource="{Binding RankedTeams}">
                 <CollectionView.ItemTemplate>
                     <DataTemplate>
-                        <Frame Margin="0,8" Style="{StaticResource CardFrame}">
+                        <Frame Padding="16"
+                               Margin="0,8"
+                               BackgroundColor="#EEF2FF"
+                               CornerRadius="12">
                             <VerticalStackLayout Spacing="8">
                                 <HorizontalStackLayout Spacing="12">
-                                    <Label Text="{Binding Rank}" FontAttributes="Bold" FontFamily="OpenSansSemibold" FontSize="20" />
-                                    <Label Text="{Binding TeamName}" FontAttributes="Bold" FontFamily="OpenSansSemibold" FontSize="20" />
+                                    <Label Text="{Binding Rank}"
+                                           FontAttributes="Bold"
+                                           FontSize="20" />
+                                    <Label Text="{Binding TeamName}"
+                                           FontAttributes="Bold"
+                                           FontSize="20" />
                                 </HorizontalStackLayout>
-                                <Label Text="{Binding Summary}" FontSize="14" />
-                                <Label Text="{Binding PlayersSummary}" FontSize="12" TextColor="{StaticResource TextSecondary}" />
-                        <Frame Padding="16" Margin="0,8" BackgroundColor="#EEF2FF" CornerRadius="12">
-                            <VerticalStackLayout Spacing="8">
-                                <HorizontalStackLayout Spacing="12">
-                                    <Label Text="{Binding Rank}" FontAttributes="Bold" FontSize="20" />
-                                    <Label Text="{Binding TeamName}" FontAttributes="Bold" FontSize="20" />
-                                </HorizontalStackLayout>
-                                <Label Text="{Binding Summary}" FontSize="14" />
-                                <Label Text="{Binding PlayersSummary}" FontSize="12" TextColor="#4B5563" />
+                                <Label Text="{Binding Summary}"
+                                       FontSize="14" />
+                                <Label Text="{Binding PlayersSummary}"
+                                       FontSize="12"
+                                       TextColor="#4B5563" />
                             </VerticalStackLayout>
                         </Frame>
                     </DataTemplate>
@@ -40,11 +43,11 @@
             </CollectionView>
 
             <Label Text="Upcoming Improvements"
-                   Style="{StaticResource SubsectionHeader}" />
+                   Style="{StaticResource SubsectionHeader}"
                    FontAttributes="Bold"
                    FontSize="18"
                    HorizontalOptions="Center" />
-            <Label Text="• Add persistent storage\n• Support manual match entry\n• Sync with cloud services" />
+            <Label Text="• Add persistent storage&#x0A;• Support manual match entry&#x0A;• Sync with cloud services" />
         </VerticalStackLayout>
     </ScrollView>
 </ContentPage>

--- a/MobileRankingSystem/MauiProgram.cs
+++ b/MobileRankingSystem/MauiProgram.cs
@@ -1,6 +1,8 @@
+using CommunityToolkit.Maui;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls.Hosting;
 using Microsoft.Maui.Hosting;
+using Syncfusion.Maui.Core.Hosting;
 
 namespace MobileRankingSystem;
 
@@ -11,6 +13,8 @@ public static class MauiProgram
         var builder = MauiApp.CreateBuilder();
         builder
             .UseMauiApp<App>()
+            .UseMauiCommunityToolkit()
+            .ConfigureSyncfusionCore()
             .ConfigureFonts(fonts =>
             {
                 fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");

--- a/MobileRankingSystem/MobileRankingSystem.csproj
+++ b/MobileRankingSystem/MobileRankingSystem.csproj
@@ -14,15 +14,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <MauiXaml Update="App.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </MauiXaml>
-    <MauiXaml Update="AppShell.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </MauiXaml>
-    <MauiXaml Update="MainPage.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </MauiXaml>
+    <Compile Remove="Platforms\**\*.cs" />
+    <Compile Remove="Platforms\**\*.xaml.cs" />
+    <None Remove="Platforms\**" />
+    <MauiXaml Remove="Platforms\**\*.xaml" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
+    <Compile Include="Platforms\Android\**\*.cs" />
+    <None Include="Platforms\Android\AndroidManifest.xml" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
+    <Compile Include="Platforms\iOS\**\*.cs" />
+    <None Include="Platforms\iOS\**\*.plist" />
   </ItemGroup>
   <ItemGroup>
     <MauiIcon Include="Resources/AppIcon/appicon.svg"
@@ -36,5 +41,14 @@
   <ItemGroup>
     <MauiFont Include="Resources/Fonts/OpenSans-Regular.ttf" Alias="OpenSansRegular" />
     <MauiFont Include="Resources/Fonts/OpenSans-Semibold.ttf" Alias="OpenSansSemibold" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.100" />
+    <PackageReference Include="CommunityToolkit.Maui" Version="12.2.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="Syncfusion.Maui.Core" Version="31.1.21" />
+    <PackageReference Include="Syncfusion.Maui.Charts" Version="31.1.21" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.9" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- conditionally include platform-specific source files to stop duplicate type definitions when multi-targeting
- add CommunityToolkit, Syncfusion, and SQLite package references required by the page models and services
- register the toolkit and Syncfusion hosting extensions inside MauiProgram

## Testing
- not run (dotnet CLI is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d81f701490832e9ba3d6d1f2c656c2