### PR TITLE
Restore MAUI XAML layout and dependencies

### DIFF
--- a/MobileRankingSystem/App.xaml
+++ b/MobileRankingSystem/App.xaml
@@ -8,14 +8,6 @@
                 <ResourceDictionary Source="Resources/Styles/Colors.xaml" />
                 <ResourceDictionary Source="Resources/Styles/Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
-            <Color x:Key="PrimaryColor">#2563EB</Color>
-            <Color x:Key="SecondaryColor">#4F46E5</Color>
-            <Style TargetType="ContentPage">
-                <Setter Property="BackgroundColor" Value="White" />
-            </Style>
-            <Style TargetType="Label">
-                <Setter Property="TextColor" Value="#1F2937" />
-            </Style>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/MobileRankingSystem/MainPage.xaml
+++ b/MobileRankingSystem/MainPage.xaml
@@ -11,28 +11,28 @@
         <VerticalStackLayout Padding="24" Spacing="16">
             <Label Text="Team Rankings"
                    Style="{StaticResource SectionHeader}" />
-                   FontAttributes="Bold"
-                   FontSize="24"
-                   HorizontalOptions="Center" />
+
             <CollectionView ItemsSource="{Binding RankedTeams}">
                 <CollectionView.ItemTemplate>
                     <DataTemplate>
-                        <Frame Margin="0,8" Style="{StaticResource CardFrame}">
+                        <Frame Margin="0,8"
+                               Style="{StaticResource CardFrame}">
                             <VerticalStackLayout Spacing="8">
                                 <HorizontalStackLayout Spacing="12">
-                                    <Label Text="{Binding Rank}" FontAttributes="Bold" FontFamily="OpenSansSemibold" FontSize="20" />
-                                    <Label Text="{Binding TeamName}" FontAttributes="Bold" FontFamily="OpenSansSemibold" FontSize="20" />
+                                    <Label Text="{Binding Rank}"
+                                           FontAttributes="Bold"
+                                           FontFamily="OpenSansSemibold"
+                                           FontSize="20" />
+                                    <Label Text="{Binding TeamName}"
+                                           FontAttributes="Bold"
+                                           FontFamily="OpenSansSemibold"
+                                           FontSize="20" />
                                 </HorizontalStackLayout>
-                                <Label Text="{Binding Summary}" FontSize="14" />
-                                <Label Text="{Binding PlayersSummary}" FontSize="12" TextColor="{StaticResource TextSecondary}" />
-                        <Frame Padding="16" Margin="0,8" BackgroundColor="#EEF2FF" CornerRadius="12">
-                            <VerticalStackLayout Spacing="8">
-                                <HorizontalStackLayout Spacing="12">
-                                    <Label Text="{Binding Rank}" FontAttributes="Bold" FontSize="20" />
-                                    <Label Text="{Binding TeamName}" FontAttributes="Bold" FontSize="20" />
-                                </HorizontalStackLayout>
-                                <Label Text="{Binding Summary}" FontSize="14" />
-                                <Label Text="{Binding PlayersSummary}" FontSize="12" TextColor="#4B5563" />
+                                <Label Text="{Binding Summary}"
+                                       FontSize="14" />
+                                <Label Text="{Binding PlayersSummary}"
+                                       FontSize="12"
+                                       TextColor="{StaticResource TextSecondary}" />
                             </VerticalStackLayout>
                         </Frame>
                     </DataTemplate>
@@ -41,10 +41,10 @@
 
             <Label Text="Upcoming Improvements"
                    Style="{StaticResource SubsectionHeader}" />
-                   FontAttributes="Bold"
-                   FontSize="18"
-                   HorizontalOptions="Center" />
-            <Label Text="• Add persistent storage\n• Support manual match entry\n• Sync with cloud services" />
+
+            <Label Text="• Add persistent storage&#x0a;• Support manual match entry&#x0a;• Sync with cloud services"
+                   TextColor="{StaticResource TextSecondary}"
+                   FontSize="14" />
         </VerticalStackLayout>
     </ScrollView>
 </ContentPage>

--- a/MobileRankingSystem/MobileRankingSystem.csproj
+++ b/MobileRankingSystem/MobileRankingSystem.csproj
@@ -37,4 +37,8 @@
     <MauiFont Include="Resources/Fonts/OpenSans-Regular.ttf" Alias="OpenSansRegular" />
     <MauiFont Include="Resources/Fonts/OpenSans-Semibold.ttf" Alias="OpenSansSemibold" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.100" />
+  </ItemGroup>
 </Project>

--- a/MobileRankingSystem/Resources/Styles/Styles.xaml
+++ b/MobileRankingSystem/Resources/Styles/Styles.xaml
@@ -5,18 +5,20 @@
         <Setter Property="BackgroundColor" Value="{StaticResource PageBackground}" />
     </Style>
 
-    <Style TargetType="Label">
+    <Style x:Key="BaseLabelStyle" TargetType="Label">
         <Setter Property="TextColor" Value="{StaticResource TextPrimary}" />
         <Setter Property="FontFamily" Value="OpenSansRegular" />
     </Style>
 
-    <Style x:Key="SectionHeader" TargetType="Label" BasedOn="{StaticResource {x:Type Label}}">
+    <Style TargetType="Label" BasedOn="{StaticResource BaseLabelStyle}" />
+
+    <Style x:Key="SectionHeader" TargetType="Label" BasedOn="{StaticResource BaseLabelStyle}">
         <Setter Property="FontSize" Value="24" />
         <Setter Property="FontAttributes" Value="Bold" />
         <Setter Property="HorizontalOptions" Value="Center" />
     </Style>
 
-    <Style x:Key="SubsectionHeader" TargetType="Label" BasedOn="{StaticResource {x:Type Label}}">
+    <Style x:Key="SubsectionHeader" TargetType="Label" BasedOn="{StaticResource BaseLabelStyle}">
         <Setter Property="FontSize" Value="18" />
         <Setter Property="FontAttributes" Value="Bold" />
         <Setter Property="HorizontalOptions" Value="Center" />


### PR DESCRIPTION
## Summary
- restore the application resource dictionary merging the shared color and style dictionaries so the XAML shell can load
- fix the MainPage XAML structure and styles so the rankings list renders with the shared card styling
- add the Microsoft.Maui.Controls package reference required by .NET 8 and reorganize shared styles for consistent label styling

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d81f701490832e9ba3d6d1f2c656c2